### PR TITLE
Fix manifest name

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
     "short_name": "WeDo",
-    "name": "he ToDo App that Syncs ❤️",
+    "name": "The ToDo App that Syncs ❤️",
     "start_url": "index.html",
     "icons": [
       {


### PR DESCRIPTION
## Summary
- correct typo in manifest name

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6843051885108327830384cb07bde550