### PR TITLE
Fix toggleTask persistence

### DIFF
--- a/js/wedo.js
+++ b/js/wedo.js
@@ -92,7 +92,8 @@ document.addEventListener('alpine:init', () => {
         },
         toggleTask(index) {
             let task = this.tasks[index]
-            task.done != task.done
+            task.done = !task.done
+            db.get('lists').get(Alpine.store('currentList')).get('tasks').get(task.id).put({ done: task.done })
         },
         get currentTasks() {
             return this.tasks.filter(task => task.listId === Alpine.store('currentList'))


### PR DESCRIPTION
## Summary
- toggle task done state using `=`
- persist toggle state to Gun store

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6843055946fc832799b0c84327ee2f7c